### PR TITLE
Finished Bucket Insertion

### DIFF
--- a/kadem/client.py
+++ b/kadem/client.py
@@ -12,4 +12,24 @@ from routingTable import routingTable
 # newId = int.from_bytes(hashlib.sha1("large".encode()).digest(), "little")
 # print((0>>160)^((1<<160)>>160))
 table = routingTable.RoutingTable(0, 3)
-table.insertNewNode(1<<160)
+# table.insertNewNode(1)
+table.insertNewNode(2)
+
+
+# bitMask = 1
+
+# number1 = 1
+# number2 = 3
+# movement = ~(number1^number2)
+
+# i = 0
+# while movement&bitMask:
+#     # print(bin(number1), bin(number2))
+#     # number2 = number2 >>1
+#     # number1 = number1 >>1
+#     # print(number1&bitMask, number2&bitMask, "----", i)
+#     # i += 1
+#     # if i > 5:
+#         # break
+#     print("sad")
+#     movement >>= 1

--- a/kadem/client.py
+++ b/kadem/client.py
@@ -13,7 +13,7 @@ from routingTable import routingTable
 # print((0>>160)^((1<<160)>>160))
 table = routingTable.RoutingTable(0, 3)
 # table.insertNewNode(1)
-table.insertNewNode(2)
+table.insertNewNode(1<<3)
 
 
 # bitMask = 1

--- a/kadem/client.py
+++ b/kadem/client.py
@@ -8,8 +8,8 @@ from routingTable import routingTable
 # with grpc.insecure_channel('localhost:50051') as channel:
 #     stub = hash_node_pb2_grpc.HashNodeStub(channel)
 #     stub.Store(store_request_pb2.StoreRequest(key="asd", value="asdads", node_ip="[::]", node_port=50052, node_id="asdasdasd"))
-
-id = int.from_bytes(hashlib.sha1("gamer".encode()).digest(), "little")
-newId = int.from_bytes(hashlib.sha1("large".encode()).digest(), "little")
-table = routingTable.RoutingTable(id, 3)
-table.insertNewNode(newId)
+# id = int.from_bytes(hashlib.sha1("gamer".encode()).digest(), "little")
+# newId = int.from_bytes(hashlib.sha1("large".encode()).digest(), "little")
+# print((0>>160)^((1<<160)>>160))
+table = routingTable.RoutingTable(0, 3)
+table.insertNewNode(1<<160)

--- a/kadem/client.py
+++ b/kadem/client.py
@@ -8,13 +8,14 @@ from routingTable import routingTable
 # with grpc.insecure_channel('localhost:50051') as channel:
 #     stub = hash_node_pb2_grpc.HashNodeStub(channel)
 #     stub.Store(store_request_pb2.StoreRequest(key="asd", value="asdads", node_ip="[::]", node_port=50052, node_id="asdasdasd"))
-# id = int.from_bytes(hashlib.sha1("gamer".encode()).digest(), "little")
-# newId = int.from_bytes(hashlib.sha1("large".encode()).digest(), "little")
-# print((0>>160)^((1<<160)>>160))
-table = routingTable.RoutingTable(0, 3)
-# table.insertNewNode(1)
-table.insertNewNode(1<<3)
-
+id = int.from_bytes(hashlib.sha1("gasdasasdfasdfasdfdasdasdasdasdamer".encode()).digest(), "little")
+almost =0b011001101110110000001110110111101111100010111110110111000100011000101000000100101010010110000100100111100110101011001111001010101111011000111110011110010100101
+print(bin(id), almost)
+# almost = ((~id)|0)|((~(1<<160))&id)
+# print(bin(almost))
+table = routingTable.RoutingTable(id, 3)
+table.insertNewNode(almost)
+print(table)
 
 # bitMask = 1
 

--- a/kadem/client.py
+++ b/kadem/client.py
@@ -5,14 +5,16 @@ from protobuf import hash_node_pb2_grpc
 from protobuf import store_request_pb2
 from routingTable import routingTable
 
+# a = 0b0111
+# b = ((~a)&((1<<3)))|((~(1<<3))&a)
+# print(bin(b))
+
 # with grpc.insecure_channel('localhost:50051') as channel:
 #     stub = hash_node_pb2_grpc.HashNodeStub(channel)
 #     stub.Store(store_request_pb2.StoreRequest(key="asd", value="asdads", node_ip="[::]", node_port=50052, node_id="asdasdasd"))
 id = int.from_bytes(hashlib.sha1("gasdasasdfasdfasdfdasdasdasdasdamer".encode()).digest(), "little")
-almost =0b011001101110110000001110110111101111100010111110110111000100011000101000000100101010010110000100100111100110101011001111001010101111011000111110011110010100101
-print(bin(id), almost)
-# almost = ((~id)|0)|((~(1<<160))&id)
-# print(bin(almost))
+almost = ((~id)&((1<<159)))|((~(1<<159))&id)
+print(bin(almost), bin(id))
 table = routingTable.RoutingTable(id, 3)
 table.insertNewNode(almost)
 print(table)

--- a/kadem/dataStructures/kBucket.py
+++ b/kadem/dataStructures/kBucket.py
@@ -1,4 +1,7 @@
 class kBucket:
-    def __init__(self, k : int, id : int):
-        self.k = k
-        self.nodes : list[str] = [id] #should be sorted by access time
+    def __init__(self, k : int):
+        self.__k = k
+        self.__nodes : list[str] = [] #should be sorted by access time
+    
+    def insert(self, id):
+        self.__nodes.append(id)

--- a/kadem/dataStructures/treeNode.py
+++ b/kadem/dataStructures/treeNode.py
@@ -5,7 +5,6 @@ class TreeNode:
         self.bucket = None
         if leafHuh:
             self.bucket = kBucket.kBucket(k, prefix)
-        self.prefix = prefix
         self.left = None
         self.right = None
         

--- a/kadem/dataStructures/treeNode.py
+++ b/kadem/dataStructures/treeNode.py
@@ -1,10 +1,16 @@
 from dataStructures import kBucket
 
 class TreeNode:
-    def __init__(self, leafHuh : bool, k : int,  prefix : int):
-        self.bucket = None
+    def __init__(self, leafHuh : bool, k : int):
+        self.__bucket = None
+        self.leafHuh = leafHuh
+        self.__k = k
         if leafHuh:
-            self.bucket = kBucket.kBucket(k, prefix)
+            self.__bucket = kBucket.kBucket(k)
         self.left = None
         self.right = None
-        
+    
+    def insert(self, id : int):        
+        if not self.leafHuh:
+            raise Exception(f"Trying to insert {id} into non leaf node")
+        self.__bucket.insert(id)

--- a/kadem/routingTable/routingTable.py
+++ b/kadem/routingTable/routingTable.py
@@ -49,34 +49,26 @@ class RoutingTable:
     def __splitParent(self, moveBit : int, parent : treeNode.TreeNode, currentNode : treeNode.TreeNode) -> treeNode.TreeNode:
         newLeaf = treeNode.TreeNode(True, self.k)
         newRoot  = treeNode.TreeNode(False, self.k)
-        if parent:
-            if moveBit:
-                newRoot.right = currentNode
-                newRoot.left = newLeaf
-            else:
-                newRoot.left = currentNode
-                newRoot.right = newLeaf
-            if parent.right is currentNode:
-                parent.right = newRoot
-            else:
-                parent.left = newRoot
+        if moveBit:
+            newRoot.right = currentNode
+            newRoot.left = newLeaf
         else:
-            self.root = newRoot
-            if moveBit:
-                newRoot.right = currentNode
-                newRoot.left = newLeaf
-            else:
-                newRoot.left = currentNode
-                newRoot.right = newLeaf
+            newRoot.left = currentNode
+            newRoot.right = newLeaf
+        if parent.right is currentNode:
+            parent.right = newRoot
+        else:
+            parent.left = newRoot
         return newRoot
 
-    def __generatePath(self, id) -> None:
-        currentNode = self.root
-        parent = None
-        movementBits = ~(id^self.id) #0 if bits were not same, else 1
+    def __generatePath(self, newId : int) -> None:
+        parent = self.root
+        currentNode = parent.left
+        if self.id&1 == 1:
+            currentNode = parent.right
+        movementBits = ~(newId^self.id) #0 if bits were not same, else 1
         bitMask = 1
-        currentInsertIdBit = id
-
+        currentInsertIdBit = newId
         while bitMask&movementBits == 1:
             moveBit = bitMask&currentInsertIdBit
             if (moveBit and not currentNode.right) or (not moveBit and not currentNode.left):
@@ -89,17 +81,8 @@ class RoutingTable:
                     currentNode = currentNode.left
             movementBits >>= 1
             currentInsertIdBit >>= 1
-
-        #at the node which id to be inserted diverges from HashNode(server) id
-        moveBit = bitMask&currentInsertIdBit
-        if (moveBit and not currentNode.right) or (not moveBit and not currentNode.left):
-            parent = self.__splitParent(moveBit, parent, currentNode)
-        else:
-            parent = currentNode
-            if moveBit:
-                currentNode = currentNode.right
-            else:
-                currentNode = currentNode.left
+        #Current Node at this point will be the node in which after following the appropriate direction down will have the kbucket
+        #Essentially this Node represents the longest common suffix of the HashNode id and the inserted id
 
     def __kBucketInsert(self, id) -> None:
         pass

--- a/kadem/routingTable/routingTable.py
+++ b/kadem/routingTable/routingTable.py
@@ -52,7 +52,8 @@ class RoutingTable:
             print("=====================")
             print(self)
             print("=====================")
-            if (moveBit and not currentNode.right) or (not moveBit and not currentNode.left) :
+            #TODO seperate insertion and traversal instead of doing both at the same time its really confusing right now
+            if (moveBit and not currentNode.right) or (not moveBit and not currentNode.left) : #TODO NEED TO ADD THE traversal version of this (no insertion)
                 if parent:
                     newLeaf = treeNode.TreeNode(True, self.k, -1)
                     newSubRoot  = treeNode.TreeNode(False, self.k, -1)

--- a/kadem/routingTable/routingTable.py
+++ b/kadem/routingTable/routingTable.py
@@ -1,17 +1,6 @@
 from dataStructures import treeNode
 from collections import deque 
 
-def getBinary(num, digs):
-    ans = ""
-    mask = 1
-    for i in range(digs):
-        if num&mask == 0:
-            ans += "0"
-        else:
-            ans += "1"
-        num>>1
-    return ans[::-1]
-
 class RoutingTable:
     #id - 160 bit sha1 id
     #k - global paramter which represents bucket size
@@ -84,8 +73,16 @@ class RoutingTable:
         #Current Node at this point will be the node in which after following the appropriate direction down will have the kbucket
         #Essentially this Node represents the longest common suffix of the HashNode id and the inserted id
 
-    def __kBucketInsert(self, id) -> None:
-        pass
+    def __kBucketInsert(self, newId) -> None:
+        bitMask = 1
+        currentNode = self.root
+        while not currentNode.leafHuh:
+            if bitMask&newId:
+                currentNode = currentNode.right
+            else:
+                currentnode = currentNode.left
+            newId >>= 1
+        currentNode.insert(newId)
 
     def insertNewNode(self, id : int) -> None:
         if id == self.id:

--- a/kadem/routingTable/routingTable.py
+++ b/kadem/routingTable/routingTable.py
@@ -48,10 +48,6 @@ class RoutingTable:
         currentInsertIdBit = id
         while bitMask&movementBits == 1:
             moveBit = bitMask&currentInsertIdBit
-            print(bin(currentInsertIdBit), moveBit)
-            print("=====================")
-            print(self)
-            print("=====================")
             #TODO seperate insertion and traversal instead of doing both at the same time its really confusing right now
             if (moveBit and not currentNode.right) or (not moveBit and not currentNode.left) : #TODO NEED TO ADD THE traversal version of this (no insertion)
                 if parent:
@@ -107,10 +103,7 @@ class RoutingTable:
             else:
                 newRoot.right = currentNode
                 newRoot.left = newLeaf
-        print("=====================")
-        print(self)
-        print("=====================")
-        #while msb the same
+        #while lsb the same
             #if the appropraite direction is availavble (1 -> right, 0 left)
                 #move in that direction and shift the bits as needed
             #else

--- a/kadem/routingTable/routingTable.py
+++ b/kadem/routingTable/routingTable.py
@@ -13,9 +13,67 @@ class RoutingTable:
             print("Why am I adding myself")
             return
         currentNode = self.root
+        parent = None
         #need to keep track of parent as that where the break happens, exceptional case for when root gets split
         currentInsertIdBit = id
         currentIdBit = self.id
+        while not (currentIdBit>>160)^(currentInsertIdBit>>160):
+            moveBit = currentInsertIdBit>>160
+            if (moveBit and not currentNode.right) or (not moveBit and not currentNode.left) :
+                if parent:
+                    newLeaf = treeNode.TreeNode(True, self.k, -1)
+                    newSubRoot  = treeNode.TreeNode(False, self.k, -1)
+                    if moveBit:
+                        newSubRoot.right = currentNode
+                        newSubRoot.left = newLeaf
+                    else:
+                        newSubRoot.left = currentNode
+                        newSubRoot.right = newLeaf
+                    shiftedRight = parent.right is currentNode
+                    if shiftedRight:
+                        parent.right = newSubRoot
+                    else:
+                        parent.left = newSubRoot
+                    currentNode = newSubRoot
+                else:
+                    newRoot = treeNode.TreeNode(False, self.k, 0)
+                    newLeaf = treeNode.TreeNode(True, self.k, -1) #idk how to do the prefix thing rn
+                    self.root = newRoot
+                    if moveBit:
+                        newRoot.right = currentNode
+                        newRoot.left = newLeaf
+                    else:
+                        newRoot.left = currentNode
+                        newRoot.right = newLeaf
+            parent = currentNode
+            currentInsertIdBit << 1
+            currentIdBit << 1
+            if moveBit:
+                currentNode = currentNode.right
+            else:
+                currentNode = currentNode.left
+        moveBit = currentInsertIdBit>>160
+        if parent:
+            if moveBit:
+                if parent.right:
+                    parent.right.bucket.append(id)
+                else:
+                    parent.right = treeNode.TreeNode(True, self.k, id)
+            else:
+                if parent.left:
+                    parent.left.bucket.append(id)
+                else:
+                    parent.left = treeNode.TreeNode(True, self.k, id)
+        else:
+            newRoot = treeNode.TreeNode(False, self.k, 0)
+            newLeaf = treeNode.TreeNode(True, self.k, id)
+            self.root = newRoot
+            if moveBit:
+                newRoot.left = currentNode
+                newRoot.right = newLeaf
+            else:
+                newRoot.right = currentNode
+                newRoot.left = newLeaf
 
         #while msb the same
             #if the appropraite direction is availavble (1 -> right, 0 left)
@@ -33,8 +91,5 @@ class RoutingTable:
             #else
                 #go up to parent and see if k bucklet exists, if yes add yourself if no make it and add yourself
 
-
-        
-    
     def getKClosestNodes():
         pass


### PR DESCRIPTION
Routing tables are represented as bit binary trees. When new nodes are added the kBuckets in the binary trees split of to match the longest common suffix of the Routing Table Id (HashNode ID) and the new Id to be inserted. Formal testing suites are needed to ensure that this works as expected. But in general testing it seems to be functioning as required. 